### PR TITLE
Fix link to call for paper.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,7 +21,7 @@
         {% endif %}
         <p>The 15th International <wbr> Modelica Conference <br> Aachen, Oct 9-11, 2023</p>
         <p>
-        <a href="{{ "/call2023.md" | absolute_url }}">[Call for Papers]</a>
+        <a href="{{ "/call2023.html" | absolute_url }}">[Call for Papers]</a>
         </p>
       </header>
       <section>


### PR DESCRIPTION
The link lead to a Markdown file, which will be downloaded in the browser. Fixed by linking to HTML.